### PR TITLE
T356618: remove broken tool reference from footer

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -49,12 +49,6 @@
 			</p>
 			<p>
 				<WikitLink
-					v-i18n="{ msg: 'query-builder-footer-curious-facts' }"
-					href="https://wikidata-analytics.wmcloud.org/app/CuriousFacts"
-				/>
-			</p>
-			<p>
-				<WikitLink
 					v-i18n="{ msg: 'query-builder-footer-constraints-violation-checker' }"
 					href="https://github.com/wmde/wikidata-constraints-violation-checker"
 				/>


### PR DESCRIPTION
Hi there :wave:

As a part of exploring WMDE tools that are currently broken in [T356618](https://phabricator.wikimedia.org/T356618), I found that there's a reference to one of them in the Query Builder Footer. The broken link is the following:

https://wikidata-analytics.wmcloud.org/app/CuriousFacts

This commit removes the reference. Please let me know if there's anything else I should do!